### PR TITLE
Fixes small formatting bug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ Instead, to drop all your local changes and commits, fetch the latest history fr
 $ git fetch origin
 
 $ git reset --hard origin/master
-``
+```


### PR DESCRIPTION
There were only two backticks in the markdown, which showed in the file instead of closing the code block.